### PR TITLE
Section header fully implemented

### DIFF
--- a/src/components/SectionHeader/SectionHeader.js
+++ b/src/components/SectionHeader/SectionHeader.js
@@ -1,0 +1,81 @@
+import React, { useEffect, useCallback, useState } from 'react';
+import './styles.css';
+
+/**
+ * Responsive section header component. Title and subtitle text are passed in as props.
+ * Has 3 lines across the page broken up into left and right lines, split by title and subtitle text. 
+ */
+export default function SectionHeader(props) {
+
+  // State hooks for title and subtitle width; since the right lines need to be calculated dynamically.
+  // Also includes hooks for styling the right lines just for cleanliness (calculations altogether).
+  const [titleWidth, setTitleWidth] = useState(0);
+  const [subtitleWidth, setSubtitleWidth] = useState(0);
+  const [styleTitleLineWidth, setstyleTitleLineWidth] = useState({});
+  const [styleSubtitleLineWidth, setstyleSubtitleLineWidth] = useState({});
+
+  /**
+   * Computes and returns width of given text based on its corresponding CSS style.
+   * @param string text to calculate width of
+   * @param string className of CSS style to apply to text for calculations
+   * @returns width of styled text
+   */
+  const measureWidth = (text, className) => {
+    // creates document element for computation
+    const tempElement = document.createElement('div');
+    tempElement.className = className;
+    tempElement.textContent = text;
+
+    // appends, calculates width, removes
+    document.body.appendChild(tempElement);
+    const width = tempElement.clientWidth;
+    document.body.removeChild(tempElement);
+
+    return width;
+  };
+
+  /**
+   * If title and subtitle were properly passed in (ie. properly formatted component),
+   * calculate and set the widths. Also set styles of the right title and subtitle lines.
+   */
+  const setWidthAndStyles = useCallback(() => {
+    if (props.title && props.subtitle){
+      setTitleWidth(measureWidth(props.title, 'text title'));
+      setSubtitleWidth(measureWidth(props.subtitle, 'text subtitle'));
+      
+      setstyleTitleLineWidth({ width: `calc(100% - ${titleWidth}px - 12%)` });
+      setstyleSubtitleLineWidth({ width: `calc(100% - ${subtitleWidth}px - 12%)` });
+    }
+  }, [props.title, props.subtitle, titleWidth, subtitleWidth]);
+
+
+  /**
+   * Sets width and styles needed, and also adds window resize event listener.
+   */
+  useEffect(() => {
+    setWidthAndStyles();
+    window.addEventListener("resize", setWidthAndStyles, false);
+  }, [setWidthAndStyles]);
+
+
+  return (
+    <div className="parent">
+      <div className="line-container">
+        <div className="leftline top"></div>
+        <div className="leftline mid"></div>
+        <div className="leftline bot"></div>
+      </div>
+      
+      <div className="line-container">
+        <div className="rightline top" style={styleTitleLineWidth}></div>
+        <div className="rightline mid" style={styleTitleLineWidth}></div>
+        <div className="rightline bot" style={styleSubtitleLineWidth}></div>
+      </div>
+
+      <div className="text-container">
+        <div className="text title">{props.title}</div>
+        <div className="text subtitle">{props.subtitle}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SectionHeader/styles.css
+++ b/src/components/SectionHeader/styles.css
@@ -1,0 +1,74 @@
+@import url('https://fonts.googleapis.com/css2?family=Averia+Sans+Libre:wght@700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Averia+Sans+Libre:wght@700&family=Karma:wght@600&display=swap');
+
+/* Line styling. 
+Includes container, left and right line aligning positioning, and color/positioning for indiivudal lines.*/
+
+.line-container{
+  width: 100%; 
+  height: 100%; 
+  position: relative;
+}
+
+.leftline {
+  width: 10%; 
+  height: 0px; 
+  left: 0px;
+
+  position: absolute;
+}
+
+.rightline {
+  width: 100%;
+  height: 0px; 
+  right: 0px;
+
+  position: absolute;
+}
+
+.top{
+  top: 0px; 
+  border: 1px #728F6E solid
+}
+
+.mid {
+  top: 17px; 
+  border: 1px #F7A325 solid
+}
+
+.bot {
+  top: 29.75px; 
+  border: 1px #F56038 solid
+}
+
+
+/* Text styling.
+Overall text positioning and width (for calculations), plus individual title and subtitle styles. */
+
+.text {
+  position: relative;
+  top: -12px;
+  width: fit-content;
+  left: 11%
+}
+
+.title {
+  color: #3B2B23;
+  font-size: 32px;
+  font-family: Averia Sans Libre;
+  font-weight: 700;
+  line-height: 44.75px;
+  letter-spacing: 0.96px;
+  word-wrap: break-word
+}
+
+/* */
+.subtitle {
+  color: #728F6E;
+  font-size: 24px;
+  font-family: Karma;
+  font-weight: 600;
+  word-wrap: break-word;
+
+  max-width: 50% 
+}

--- a/src/components/SectionHeader/styles.css
+++ b/src/components/SectionHeader/styles.css
@@ -62,7 +62,6 @@ Overall text positioning and width (for calculations), plus individual title and
   word-wrap: break-word
 }
 
-/* */
 .subtitle {
   color: #728F6E;
   font-size: 24px;


### PR DESCRIPTION
Completed section header! Tested it out in App.js with multiple and seems to be fine, did not test with other components though since there are none.

We didn't define so I was unsure about:
- CSS styling ,so I made just a normal CSS file for now since @jeremynguyen593 you said you preferred to keep to just CSS and I lowkey didn't know what that meant; can update to CSS module whenever probably? (never used, just researched and assumed. should not be hard just changing to .module.css then changing import) 
- Also unsure about documenting style so I did what I knew (fully documented though), should probably outline how we wanna comment things!

Based on UI/UX designs, some things were also pretty arbitrary:
- Paragraph widths for subtitles so I set it to 50% and can adjust if UI/UX wants more compact paragraphs
- Line sizes on the left _before_ the text. Set to 10% but again if they want farther go for it (adjustment of this means adjustment of `setWidthAndStyles` function. Right line width is currently calculated (accounting for left lines + buffer) as 12%; so adjust value accordingly (+2%, or however you feel))